### PR TITLE
Add IP validation before updating DNS record

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"time"
@@ -65,6 +66,11 @@ func main() {
 				continue
 			}
 
+			if !isValidIP(currentIP) {
+				log.Printf("Invalid IP address: '%s'", currentIP)
+				continue
+			}
+	
 			log.Printf("Current public IP: %s", currentIP)
 
 			if currentIP != recordIP {
@@ -122,4 +128,8 @@ func updateDNSRecord(api *cloudflare.API, zoneID, recordID, newIP string) error 
 		Content: newIP,
 	})
 	return err
+}
+
+func isValidIP(ip string) bool {
+    return net.ParseIP(ip) != nil
 }


### PR DESCRIPTION
Occasionally I see the following output in the logs:

> 2025/02/18 06:22:27 Current public IP: error
> 2025/02/18 06:22:27 IP has changed from [redacted] to error. Updating DNS record...
> 2025/02/18 06:22:28 Error updating DNS record: Content for A record must be a valid IPv4 address. (9005)

This update will stop from calling the CloudFlare API when an invalid IP address was returned from api.ipify.org